### PR TITLE
[Dependencies] Update Sources

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/go.crypto/scrypt"
+	"golang.org/x/crypto/scrypt"
 	"github.com/DHowett/ghostbin/account"
 	"github.com/golang/glog"
 	"github.com/golang/groupcache/lru"

--- a/paste.go
+++ b/paste.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"code.google.com/p/go.crypto/scrypt"
+	"golang.org/x/crypto/scrypt"
 	"crypto/aes"
 	"crypto/cipher"
 	"github.com/DHowett/go-xattr"


### PR DESCRIPTION
code.google.com is dead, so go get will fail. Updated to use golang's sources instead.