### PR TITLE
fix import for scrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ sessions/session_*
 templates/_local.tmpl
 xattr
 accounts/*
+.idea
 
 node_modules
 build

--- a/auth.go
+++ b/auth.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"code.google.com/p/go.crypto/scrypt"
+	"golang.org/x/crypto/scrypt"
 	"github.com/DHowett/ghostbin/account"
 	"github.com/golang/glog"
 	"github.com/golang/groupcache/lru"

--- a/paste.go
+++ b/paste.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"code.google.com/p/go.crypto/scrypt"
+	"golang.org/x/crypto/scrypt"
 	"crypto/aes"
 	"crypto/cipher"
 	"github.com/DHowett/go-xattr"


### PR DESCRIPTION
resolves "package code.google.com/p/go.crypto/scrypt: unable to detect version control system for code.google.com/ path" on go get