### PR TITLE
Remove single quotes around generic font family name in CSS

### DIFF
--- a/public/css/master.less
+++ b/public/css/master.less
@@ -135,7 +135,7 @@ input[type=password] {
 }
 
 .code, code {
-	font-family: 'EnvyCodeRWeb', 'monospace';
+	font-family: 'EnvyCodeRWeb', monospace;
 	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	font-size: @paste-font-size;


### PR DESCRIPTION
See issue #65 