### PR TITLE
Fix link on about page

### DIFF
--- a/ATTIC/templates/about.tmpl
+++ b/ATTIC/templates/about.tmpl
@@ -52,7 +52,7 @@ do exist, but I found them to be somewhat lacking:
 <p>
 Ghostbin is an attempt at not only solving the above, but also solving
 some issues in the industry such as, but not limited to, me not
-knowing Go. It&rsquo;s <a href="http://git.howett.net/paste.git">open-source</a>
+knowing Go. It&rsquo;s <a href="https://github.com/DHowett/spectre" target="_blank">open-source</a>
 and I don&rsquo;t think it&rsquo;ll be going anywhere any time soon.
 It supports encryption, expiration, pastes up to one megabyte, and
 about six billion languages. Well, some hundreds at the very least.


### PR DESCRIPTION
The link on the about page was redirecting to the wrong repo